### PR TITLE
[FEATURE] Allow explicit link target language selection.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+2016-12-20 Leonie Bitto <leonie@netcreators.nl>
+
+  * 2.1.0
+  * FEATURE Allow explicit link target language selection.
+    - BUGFIX Define default value for DB field pages.tx_shortcutstatuscodes_language to be -1, which
+      equals \Webit\ShortcutStatuscodes\Controller\ShortcutStatuscodesTypoScriptFrontendController::LANGUAGE_OPTION_NONE.
+    - BUGFIX Allow links to localized pages without default language content.
+
 2016-08-24 Dan Untenzu <untenzu@webit.de>
 
   * 2.0.0

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -1,0 +1,32 @@
+<?php
+
+$additionalColumns = array(
+	'tx_shortcutstatuscodes_language' => array(
+		'exclude' => 0,
+		'label' => 'LLL:EXT:shortcut_statuscodes/Resources/Private/Language/locallang_tca.xlf:pages.tx_shortcutstatuscodes_language_formlabel',
+		'displayCond' => 'FIELD:shortcut_mode:=:' . \TYPO3\CMS\Frontend\Page\PageRepository::SHORTCUT_MODE_NONE,
+		'config' => array(
+			'type' => 'select',
+			'special' => 'languages',
+			'items' => array (
+				array(
+					'LLL:EXT:shortcut_statuscodes/Resources/Private/Language/locallang_tca.xlf:pages.tx_shortcutstatuscodes_void_option',
+					\Webit\ShortcutStatuscodes\Controller\ShortcutStatuscodesTypoScriptFrontendController::LANGUAGE_OPTION_NONE
+				),
+			),
+		)
+	),
+);
+
+$GLOBALS['TCA']['pages']['ctrl']['requestUpdate'] .= ($GLOBALS['TCA']['pages']['ctrl']['requestUpdate'] ? ',' : '') . 'shortcut_mode';
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns(
+	'pages',
+	$additionalColumns
+);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToPalette(
+	'pages',
+	'shortcut',
+	'tx_shortcutstatuscodes_language',
+	'after:shortcut_mode'
+);

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.0" xmlns:t3="http://typo3.org/schemas/xliff">
+	<file t3:id="1462876547" source-language="en" datatype="plaintext" original="messages" date="2016-05-10T11:34:32Z" product-name="shortcut_statuscodes">
+		<header/>
+		<body>
+			<trans-unit id="pages.tx_shortcutstatuscodes_language_formlabel" xml:space="preserve">
+				<source>Explicit link target page language</source>
+			</trans-unit>
+			<trans-unit id="pages.tx_shortcutstatuscodes_void_option" xml:space="preserve">
+				<source>-</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,5 @@
   "support": {
     "issues": "https://github.com/webit-de/typo3-shortcut_statuscodes/issues"
   },
-  "version": "2.0.0"
+  "version": "2.1.0"
 }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -14,8 +14,8 @@ $EM_CONF[$_EXTKEY] = array(
 	'title' => 'Different HTTP statuscodes for shortcuts',
 	'description' => 'Restore the use of different HTTP statuscodes for shortcuts (307 redirect to first subpage, random subpage, parent page – 301 for redirect to explicitly selected page)',
 	'category' => 'misc',
-	'author' => 'Dan Untenzu',
-	'author_email' => 'untenzu@webit.de',
+	'author' => 'Dan Untenzu, Leonie Bitto [Netcreators]',
+	'author_email' => 'untenzu@webit.de, extensions@netcreators.nl',
 	'shy' => '',
 	'dependencies' => '',
 	'conflicts' => '',
@@ -29,7 +29,7 @@ $EM_CONF[$_EXTKEY] = array(
 	'clearCacheOnLoad' => 0,
 	'lockType' => '',
 	'author_company' => '',
-	'version' => '2.0.0',
+	'version' => '2.1.0',
 	'constraints' => array(
 		'depends' => array(
 			'typo3' => '6.2.0-7.6.99',
@@ -42,4 +42,3 @@ $EM_CONF[$_EXTKEY] = array(
 	),
 );
 
-?>

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -8,4 +8,3 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects']['TYPO3\CMS\Frontend\Controller\Typ
 		'className' => 'Webit\ShortcutStatuscodes\Controller\ShortcutStatuscodesTypoScriptFrontendController'
 );
 
-?>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,0 +1,7 @@
+
+#
+# Table structure for table 'pages'
+#
+CREATE TABLE pages (
+  tx_shortcutstatuscodes_language int(11) NOT NULL default -1
+);


### PR DESCRIPTION
2016-12-20 Leonie Bitto <leonie@netcreators.nl>

  * 2.1.0
  * FEATURE Allow explicit link target language selection.
    - BUGFIX Define default value for DB field
      pages.tx_shortcutstatuscodes_language to be -1, which
      equals ShortcutStatuscodesTypoScriptFrontendController::LANGUAGE_OPTION_NONE.
    - BUGFIX Allow links to localized pages without default language content.