### PR TITLE
[TASK] Add "renderType" to "select" field

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -7,6 +7,7 @@ $additionalColumns = array(
         'displayCond' => 'FIELD:shortcut_mode:=:' . \TYPO3\CMS\Frontend\Page\PageRepository::SHORTCUT_MODE_NONE,
         'config' => array(
             'type' => 'select',
+            'renderType' => 'selectSingle',
             'special' => 'languages',
             'items' => array(
                 array(


### PR DESCRIPTION
This fixes the following deprecation message:

> Using select fields without the "renderType" setting is deprecated in table "pages" and column "tx_shortcutstatuscodes_language"